### PR TITLE
[1863] nonGeographicDataset

### DIFF
--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -397,8 +397,10 @@ class GeminiHarvester(SpatialHarvester):
 
         # Check that the extent does not have zero area - that causes a divide
         # by zero error in map searches. (DGU#782)
-        if gemini_values['bbox-north-lat'] == gemini_values['bbox-south-lat'] \
-          or gemini_values['bbox-west-long'] == gemini_values['bbox-east-long']:
+        # (although a nonGeographicDataset would not have an extent anyway)
+        if gemini_values['resource-type'] != 'nonGeographicDataset' and \
+                (gemini_values['bbox-north-lat'] == gemini_values['bbox-south-lat']
+                 or gemini_values['bbox-west-long'] == gemini_values['bbox-east-long']):
             raise ImportAbort('The Extent\'s geographic bounding box has zero area for GUID %s' % gemini_guid)
 
         # Save the metadata reference date in the Harvest Object

--- a/ckanext/spatial/plugin.py
+++ b/ckanext/spatial/plugin.py
@@ -143,6 +143,13 @@ class SpatialQuery(p.SingletonPlugin):
 
     p.implements(p.IRoutes, inherit=True)
     p.implements(p.IPackageController, inherit=True)
+    p.implements(p.IConfigurable, inherit=True)
+
+    search_backend = None
+
+    def configure(self, config):
+
+        self.search_backend = 'postgis'
 
     def before_map(self, map):
 

--- a/ckanext/spatial/tests/test_validation.py
+++ b/ckanext/spatial/tests/test_validation.py
@@ -119,6 +119,18 @@ class TestValidation:
         assert_in('(gmx.xsd)', errors)
         assert_in('Element \'srv:SV_ServiceIdentification\': This element is not expected.', errors)
 
+    def test_non_geographic_dataset_passes_gemini(self):
+        xml_filepath = 'gemini2.1/validation/non_geographic_dataset.xml'
+        errs = self.get_validation_errors(validation.ISO19139EdenSchema,
+                                          xml_filepath)
+        assert not errs, 'ISO19139EdenSchema: ' + errs
+        errs = self.get_validation_errors(validation.ConstraintsSchematron14,
+                                          xml_filepath)
+        assert not errs, 'ConstraintsSchematron14: ' + errs
+        errs = self.get_validation_errors(validation.Gemini2Schematron,
+                                          xml_filepath)
+        assert not errs, 'Gemini2Schematron: ' + errs
+
     def test_schematron_error_extraction(self):
         validation_error_xml = '''
 <root xmlns:svrl="http://purl.oclc.org/dsdl/svrl">


### PR DESCRIPTION
Validation now allows 'nonGeographicDataset' record type by bypassing GEMINI schematron and allowing it to have no extent. save_package_extent now checks for an area, in addition to check in the harvester - maybe we can remove the one in the harvester if we switch to solr geo-search backend and points can be indexed.