### PR TITLE
Switch from urllib2 to requests

### DIFF
--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -1,7 +1,7 @@
 import re
 import cgitb
 import warnings
-import urllib2
+import requests
 import sys
 import logging
 from string import Template
@@ -647,8 +647,8 @@ class SpatialHarvester(HarvesterBase):
         '''
         try:
             capabilities_url = wms.WMSCapabilitiesReader().capabilities_url(url)
-            res = urllib2.urlopen(capabilities_url, None, 10)
-            xml = res.read()
+            res = requests.get(capabilities_url)
+            xml = res.text
 
             s = wms.WebMapService(url, xml=xml)
             return isinstance(s.contents, dict) and s.contents != {}
@@ -744,8 +744,8 @@ class SpatialHarvester(HarvesterBase):
         DEPRECATED: Use _get_content_as_unicode instead
         '''
         url = url.replace(' ', '%20')
-        http_response = urllib2.urlopen(url)
-        return http_response.read()
+        http_response = requests.get(url)
+        return http_response.text
 
     def _get_content_as_unicode(self, url):
         '''

--- a/ckanext/spatial/harvesters/waf.py
+++ b/ckanext/spatial/harvesters/waf.py
@@ -4,6 +4,7 @@ from urlparse import urljoin
 import dateutil.parser
 import pyparsing as parse
 import requests
+from urllib3.contrib import pyopenssl
 from sqlalchemy.orm import aliased
 from sqlalchemy.exc import DataError
 
@@ -58,6 +59,7 @@ class WAFHarvester(SpatialHarvester, SingletonPlugin):
         self._set_source_config(harvest_job.source.config)
 
         # Get contents
+        pyopenssl.inject_into_urllib3()
         try:
             response = requests.get(source_url, timeout=60)
             response.raise_for_status()

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -6,3 +6,9 @@ owslib>=0.8.6
 lxml==3.2.4
 argparse
 requests==1.1.0
+idna==2.7
+ndg-httpsclient==0.5.1
+pyasn1==0.4.4
+pyOpenSSL==18.0.0
+urllib3==1.23
+enum34==1.1.6


### PR DESCRIPTION
`urllib2` should be upgraded to `requests` to enable support for TLSv1.2.  This does that and include backwards compatibility for versions of Python older than 2.7.9.