### PR TITLE
The HTTP request content must be returned as bytes, rather than unicode

### DIFF
--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -126,7 +126,7 @@ class GeminiSpatialHarvester(HarvesterBase):
         except httplib.HTTPException, e:
             log.info('HTTP access of %s failed due to HTTP error "%s".', url, e)
             return False
-        content = http_request.text
+        content = http_request.content
         return (content, url)
 
 

--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -209,7 +209,7 @@ class GeminiHarvester(GeminiSpatialHarvester):
         # quite safely. But we enclose in the try: block because that will
         # be needed when we start using _get_content_as_unicode in the future.
         try:
-            gemini_string = str(gemini_string)
+            gemini_string = gemini_string.decode()
         except UnicodeEncodeError:
             pass
         xml = etree.fromstring(gemini_string)


### PR DESCRIPTION
A subsequent method requires the response content to have not already been converted to unicode

Trello card: https://trello.com/c/J0IV8iNj/470-fix-these-3-harvesters-%F0%9F%8D%90-portunity