### PR TITLE
Convert unicode strings to byte strings

### DIFF
--- a/ckanext/spatial/harvesters/gemini.py
+++ b/ckanext/spatial/harvesters/gemini.py
@@ -209,7 +209,7 @@ class GeminiHarvester(GeminiSpatialHarvester):
         # quite safely. But we enclose in the try: block because that will
         # be needed when we start using _get_content_as_unicode in the future.
         try:
-            gemini_string = gemini_string.decode()
+            gemini_string = str(gemini_string)
         except UnicodeEncodeError:
             pass
         xml = etree.fromstring(gemini_string)


### PR DESCRIPTION
Lxml expects a byte string because XML includes its own encoding declaration at the beginning of the string [top of the file].

Calling decode() on either a byte string or a unicode string tries to interpret it as UTF-8 and turn it into a unicode string, therefore lxml fails to parse with an error "Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration."

Instead we can just call str() to turn it into a byte string.

This fixes [an issue with the Defra harvesters](https://trello.com/c/jybTFAqz/562-fix-this-defra-harvester).